### PR TITLE
bug fix: make compatible with older emacs versions by not using `plist-get` when getting the `previous-prompt-function`

### DIFF
--- a/sticky-shell.el
+++ b/sticky-shell.el
@@ -103,7 +103,7 @@ See the functions' own documentation for more info"
 
 (defvar sticky-shell-previous-prompt-function
   #'comint-previous-prompt
-  "Function called to retrieve the previous propmt.
+  "Variable storing the function called to retrieve the previous propmt.
 Varies depending on which mode the current major-mode is derived from.")
 
 (defface sticky-shell-shorten-header-ellipsis
@@ -119,8 +119,8 @@ Varies depending on which mode the current major-mode is derived from.")
 
 (defun sticky-shell--previous-prompt (n)
   "Move to end of Nth previous prompt in the buffer.
-Depending on the current mode, call `comint-previous-prompt'
-or `eshell-previous-prompt'."
+Call the function stored in the buffer-local variable
+`sticky-shell-previous-prompt-function'."
   (funcall sticky-shell-previous-prompt-function n))
 
 ;;;; get prompt


### PR DESCRIPTION
**Bug fix**: as reported by @bram85 in issue #1 :

`plist-get` only accepted two arguments up until `emacs-28` ([link](https://github.com/emacs-mirror/emacs/blob/emacs-28/src/fns.c#L2336)). Starting with `emacs-29`, `plist-get` now accepts three arguments ([link](https://github.com/emacs-mirror/emacs/blob/emacs-29/src/fns.c#L2472)). So the package was only compatible with emacs-version >= 29.


**Fix**:
We used `plist-get` when looking at the property-list `sticky-shell-supported-modes` to determine which of those modes was a parent of the current major mode. Instead of using `plist-get`, we now have the function `sticky-shell--get-func-for-derived-mode`, which recursively iterates through the property-list until it finds the mode. Once we determine which mode the current `major-mode` derives from, we return its `previous-prompt` function. Just as before, when our search fails we default to `comint-previous-prompt`